### PR TITLE
Gradle publish add version to freenet-without-version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ processResources.dependsOn compileVersion
 
 task jarWithVersion(type: Jar) {
     archiveName = "freenet.jar"
-    from (zipTree("$projectDir/build/libs/freenet-without-version.jar")) {
+    from (zipTree("$projectDir/build/libs/freenet-without-version-${gitrev}.jar")) {
         exclude 'freenet/node/Version.class'
         exclude 'freenet/node/Version$1.class'
     }


### PR DESCRIPTION
Adding the version to freenet-without-version fixes the gradle build problem for me. 
It does feel silly adding a version to a "without version" jar... 
Will this work OK?